### PR TITLE
Maintainers link

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,5 +1,5 @@
 ## Hyperledger Fabric Maintainers
 
-[MAINTAINERS](http://hyperledger-fabric.readthedocs.io/en/latest/MAINTAINERS.html)
+[MAINTAINERS](https://hyperledger-fabric.readthedocs.io/en/release-1.4/MAINTAINERS.html)
 
 <a rel="license" href="http://creativecommons.org/licenses/by/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by/4.0/88x31.png" /></a><br />This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Hyperledger Fabric Samples
 
-Please visit the [installation instructions](http://hyperledger-fabric.readthedocs.io/en/latest/samples.html).
+Please visit the [installation instructions](https://hyperledger-fabric.readthedocs.io/en/latest/chaincode4ade.html#install-hyperledger-fabric-samples).
 
 ## License <a name="license"></a>
 


### PR DESCRIPTION
The maintainers link was available in release 1.4 version branch only,
https://hyperledger-fabric.readthedocs.io/en/release-1.4/MAINTAINERS.html
Corrected the broken link.